### PR TITLE
Add flake8-commas plugin to lint step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: TrueBrain/actions-flake8@v2
         with:
           flake8_version: 6.0.0
-          plugins: flake8-isort==6.1.1 flake8-quotes==3.4.0
+          plugins: flake8-isort==6.1.1 flake8-quotes==3.4.0 flake8-commas==4.0.0


### PR DESCRIPTION
I use this locally to catch missing commas. Since this is a new project we can add the lint to the CI without it failing on existing code.