### PR TITLE
PR-6181 Add CMR client and launchpad auth

### DIFF
--- a/cumulus_port/_internal/pfx_to_pem.py
+++ b/cumulus_port/_internal/pfx_to_pem.py
@@ -1,0 +1,41 @@
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+from cryptography.hazmat.primitives.serialization.pkcs12 import (
+    load_key_and_certificates,
+)
+
+
+@contextmanager
+def pfx_to_pem(pfx: bytes, pfx_password: str):
+    """Decrypts the .pfx file and writes to a termporary location as a .pem"""
+    private_key, main_cert, add_certs = load_key_and_certificates(
+        pfx,
+        pfx_password.encode(),
+        None,
+    )
+
+    if private_key is None:
+        raise Exception("pfx missing private key")
+
+    if main_cert is None:
+        raise Exception("pfx missing certificate")
+
+    with NamedTemporaryFile(suffix=".pem") as t_pem:
+        with open(t_pem.name, "wb") as pem_file:
+            pem_file.write(
+                private_key.private_bytes(
+                    Encoding.PEM,
+                    PrivateFormat.PKCS8,
+                    NoEncryption(),
+                ),
+            )
+            pem_file.write(main_cert.public_bytes(Encoding.PEM))
+            for ca in add_certs:
+                pem_file.write(ca.public_bytes(Encoding.PEM))
+        yield t_pem.name

--- a/cumulus_port/aws_client/s3.py
+++ b/cumulus_port/aws_client/s3.py
@@ -1,0 +1,57 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/aws-client/src/S3.ts
+
+import re
+from typing import Union
+
+import boto3
+import botocore
+
+
+def s3_join(*args: Union[str, list[str]]) -> str:
+    """Join strings into an S3 key without a leading slash
+
+    :param args: - the strings to join
+    :returns: str - the full S3 key
+    """
+    if not args:
+        return ""
+
+    tokens: list[str]
+    if isinstance(args[0], str):
+        tokens = args
+    else:
+        tokens = args[0]
+
+    # The regexes have been combined into one to make the list comprehension
+    # below simpler.
+    def remove_slashes(token: str) -> str:
+        return re.sub(r"^/|/$", "", token)
+
+    key = "/".join([
+        stripped_token
+        for token in tokens
+        if (stripped_token := remove_slashes(token))
+    ])
+
+    if tokens[-1].endswith("/"):
+        return f"{key}/"
+    return key
+
+
+def s3_object_exists(s3: boto3.client, **kwargs) -> bool:
+    """Test if an object exists in S3
+
+    :param kwargs: same params as
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/head_object.html
+    :returns: bool - a Promise that will resolve to a boolean indicating if the
+        object exists
+    """
+    try:
+        s3.head_object(**kwargs)
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Message"] == "Not Found":
+            return False
+        raise
+
+    return True

--- a/cumulus_port/aws_client/secrets_manager.py
+++ b/cumulus_port/aws_client/secrets_manager.py
@@ -1,0 +1,16 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/aws-client/src/SecretsManager.ts
+
+import contextlib
+from typing import Optional
+
+import boto3
+
+
+def get_secret_string(secret_id: str) -> Optional[str]:
+    secrets_manager = boto3.client("secretsmanager")
+    with contextlib.suppress(Exception):
+        response = secrets_manager.get_secret_value(SecretId=secret_id)
+        return response["SecretString"]
+
+    return None

--- a/cumulus_port/cmr_client/__init__.py
+++ b/cumulus_port/cmr_client/__init__.py
@@ -1,0 +1,7 @@
+from .cmr import CMR
+from .get_url import get_search_url
+
+__all__ = [
+    "CMR",
+    "get_search_url",
+]

--- a/cumulus_port/cmr_client/cmr.py
+++ b/cumulus_port/cmr_client/cmr.py
@@ -1,0 +1,255 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/cmr-client/src/CMR.ts#L8
+
+from typing import Optional
+
+from cumulus_port.aws_client import secrets_manager as secrets_manager_utils
+from cumulus_port.common.env import get_required_env_var
+
+from .earthdata_login import get_edl_token
+from .search_concept import search_concept
+
+
+def update_token(
+    username: str,
+    password: str,
+) -> Optional[str]:
+    """Returns a valid a CMR token
+
+    :param username: CMR username
+    :param password: CMR password
+    :returns: the token
+    """
+    edl_env = get_required_env_var("CMR_ENVIRONMENT")
+    if not edl_env:
+        raise Exception("CMR_ENVIRONMENT not set")
+    return get_edl_token(username, password, edl_env)
+
+
+class CMR:
+    """A class to simplify requests to the CMR
+
+    Example:
+    >>> cmr_client = CMR(
+    ...     provider="my-provider",
+    ...     client_id="my-clientId",
+    ...     username="my-username",
+    ...     password="my-password",
+    ... )
+    ...
+
+    or
+
+    >>> cmr_client = CMR(
+    ...     provider="my-provider",
+    ...     client_id="my-clientId",
+    ...     token="cmr_or_launchpad_token",
+    ... )
+    ...
+    """
+    def __init__(
+        self,
+        *,
+        provider: str,
+        client_id: str,
+        username: Optional[str] = None,
+        password_secret_name: Optional[str] = None,
+        password: Optional[str] = None,
+        token: Optional[str] = None,
+        oauth_provider: str,
+    ):
+        """The constructor for the CMR class
+
+        :param provider: the CMR provider id
+        :param client_id: the CMR clientId
+        :param username: CMR username, not used if token is provided
+        :param password_secret_name: CMR password secret, not used if token is provided
+        :param password: CMR password, not used if token or passwordSecretName
+            is provided
+        :param token: CMR or Launchpad token, if not provided, CMR username and
+            password are used to get a cmr token
+         :param oauth_provider: Oauth provider: 'earthdata' or 'launchpad'
+        """
+        self.provider = provider
+        self.client_id = client_id
+        self.username = username
+        self.oauth_provider = oauth_provider
+        self.password_secret_name = password_secret_name
+        self.password = password
+        self.token = token
+
+    def get_cmr_password(self) -> str:
+        """Get the CMR password, from the AWS secret if set, else return the
+        password
+
+        :returns: the CMR password
+        """
+        if self.password_secret_name:
+            value = secrets_manager_utils.get_secret_string(
+                self.password_secret_name,
+            )
+
+            if not value:
+                raise Exception("Unable to retrieve CMR password")
+
+            return value
+
+        if not self.password:
+            raise Exception("No CMR password set")
+
+        return self.password
+
+    def get_token(self) -> Optional[str]:
+        """The method for getting the token
+
+        :returns: the token
+        """
+        if self.token:
+            return self.token
+
+        return update_token(self.username, self.get_cmr_password())
+
+    def get_write_headers(
+        self,
+        *,
+        token: Optional[str] = None,
+        ummg_version: Optional[str] = None,
+        cmr_revision_id: Optional[str] = None,
+    ) -> dict:
+        """Return object containing CMR request headers for PUT / POST / DELETE
+
+        :param token: CMR request token
+        :param ummg_version: UMMG metadata version string or null if echo10
+            metadata
+        :param cmr_revision_id: CMR Revision ID
+        :returns: CMR headers object
+        """
+        raise NotImplementedError()
+
+    def get_read_headers(self, *, token: Optional[str] = None) -> dict:
+        """Return object containing CMR request headers for GETs
+
+        :param token: CMR request token
+        :returns: CMR headers object
+        """
+        headers = {
+            "Client-Id": self.client_id,
+        }
+
+        if token:
+            headers["Authorization"] = token
+
+        return headers
+
+    def ingest_collection(self, xml: str):
+        """Adds a collection record to the CMR
+
+        :param xml: the collection XML document
+        :returns: the CMR response
+        """
+        raise NotImplementedError()
+
+    def ingest_granule(self, xml: str, cmr_revision_id: Optional[str] = None):
+        """Adds a granule record to the CMR
+
+        :param xml: the granule XML document
+        :param cmr_revision_id: Optional CMR Revision ID
+        :returns: the CMR response
+        """
+        raise NotImplementedError()
+
+    def ingest_umm_granule(
+        self,
+        ummg_metadata: dict,
+        cmr_revision_id: Optional[str] = None,
+    ) -> dict:
+        """Adds/Updates UMMG json metadata in the CMR
+
+        :param ummg_metadata: UMMG metadata object
+        :param cmr_revision_id: Optional CMR Revision ID
+        :returns: the CMR response object.
+        """
+        raise NotImplementedError()
+
+    def delete_collection(self, dataset_id: str):
+        """Deletes a collection record from the CMR
+
+        :param dataset_id: the collection unique id
+        :returns: the CMR response
+        """
+        raise NotImplementedError()
+
+    def delete_granule(self, granule_ur: str):
+        """Deletes a granule record from the CMR
+
+        :param granule_ur: the granule unique id
+        :returns: the CMR response
+        """
+        raise NotImplementedError()
+
+    def search_concept(
+        self,
+        type: str,
+        search_params: dict[str, str],
+        format: str = "json",
+        recursive: bool = True,
+    ) -> list:
+        headers = self.get_read_headers(token=self.get_token())
+        return search_concept(
+            type=type,
+            search_params=search_params,
+            previous_results=[],
+            headers=headers,
+            format=format,
+            recursive=recursive,
+        )
+
+    def search_collections(
+        self,
+        params: dict[str, str] = {},
+        format: str = "json",
+    ) -> list:
+        """Search in collections
+
+        :param params: the search parameters
+        :param format: format of the response
+        :returns: the CMR response
+        """
+        search_params = {
+            "provider_short_name": self.provider,
+            **params,
+        }
+        return self.search_concept(
+            "collections",
+            search_params,
+            format,
+        )
+
+    def search_granules(
+        self,
+        params: dict[str, str] = {},
+        format: str = "json",
+    ) -> list:
+        """Search in granules
+
+        :param params: the search parameters
+        :param format: format of the response
+        :returns: the CMR response
+        """
+        search_params = {
+            "provider_short_name": self.provider,
+            **params,
+        }
+        return self.search_concept(
+            "granules",
+            search_params,
+            format,
+        )
+
+    def get_granule_metadata(self, cmr_link: str):
+        """Get the granule metadata from CMR using the cmr_link
+
+        :param cmr_link: URL to concept
+        :returns: metadata as a JS object, null if not found
+        """
+        raise NotImplementedError()

--- a/cumulus_port/cmr_client/earthdata_login.py
+++ b/cumulus_port/cmr_client/earthdata_login.py
@@ -1,0 +1,177 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/cmr-client/src/EarthdataLogin.ts
+
+from typing import Optional
+
+import jwt
+import requests
+
+from cumulus_port.common import parse_caught_error
+
+
+def get_edl_url(env: str) -> str:
+    """Get the Earthdata Login endpoint URL based on the EDL environment
+
+    :param env: the environment of the Earthdata Login (ex. 'SIT')
+    :returns: str - the endpoint URL
+    """
+    if env in ("PROD", "OPS"):
+        return "https://urs.earthdata.nasa.gov"
+    if env == "UAT":
+        return "https://uat.urs.earthdata.nasa.gov"
+
+    return "https://sit.urs.earthdata.nasa.gov"
+
+
+def parse_http_error(
+    error: requests.exceptions.HTTPError,
+    request_type: str,
+) -> Exception:
+    """Parse and handle error returned from EDL endpoint
+
+    :param error: the HTTP error response returned by the EarthdataLogin
+        endpoint
+    :param request_type: the type of token request
+        (options: 'retrieve', 'create', 'revoke')
+    :returns: Exception - EarthdataLogin error
+    """
+    status_code = error.response.status_code
+    status_message = error.response.reason or "Unknown"
+    # In JavaScript the request_type is used to determine whether or not to
+    # serialize the response body. In Python, the body is not deserialized for
+    # us, so we know that we never need to serialize it again. request_type is
+    # therefore unused.
+    error_body = error.response.text
+    message = (
+        f"EarthdataLogin error: {error_body},  statusCode: {status_code}, "
+        f"statusMessage: {status_message}. Earthdata Login Request failed"
+    )
+    return Exception(message)
+
+
+def is_token_expired(token: dict) -> bool:
+    try:
+        payload = jwt.decode(
+            token["access_token"],
+            options={
+                "verify_signature": False,
+                "verify_exp": True,
+            },
+        )
+        return "exp" not in payload
+    except jwt.ExpiredSignatureError:
+        return True
+
+
+def retrieve_edl_token(
+    username: str,
+    password: str,
+    edl_env: str,
+) -> Optional[str]:
+    """Retrieve an existing valid token
+
+    :param username: the username of the Earthdata Login user
+    :param password: the password of the Earthdata Login user
+    :param edl_env: the environment of the Earthdata Login (ex. 'SIT')
+    :returns: Optional[str] - the token or None if there
+    """
+    try:
+        url = f"{get_edl_url(edl_env)}/api/users/tokens"
+        raw_response = requests.get(url, auth=(username, password))
+    except requests.exceptions.HTTPError as e:
+        raise parse_http_error(e, "retrieve")
+    except Exception as e:
+        raise parse_caught_error(e)
+
+    tokens = raw_response.json()
+    unexpired_tokens = [
+        token
+        for token in tokens
+        if "access_token" in token and not is_token_expired(token)
+    ]
+    sorted_tokens = sorted(
+        unexpired_tokens,
+        key=lambda token: jwt.decode(
+            token["access_token"],
+            options={"verify_signature": False},
+        )["exp"],
+    )
+    if sorted_tokens:
+        return sorted_tokens[-1]["access_token"]
+
+    return None
+
+
+def create_edl_token(
+    username: str,
+    password: str,
+    edl_env: str,
+) -> Optional[str]:
+    """Create a token.
+
+    :param username: the username of the Earthdata Login user
+    :param password: the password of the Earthdata Login user
+    :param edl_env: the environment of the Earthdata Login (ex. 'SIT')
+    :returns: Optional[str] - the token or undefined
+    """
+    try:
+        url = f"{get_edl_url(edl_env)}/api/users/token"
+        raw_response = requests.post(url, auth=(username, password))
+        raw_response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        raise parse_http_error(e, "create")
+    except Exception as e:
+        raise parse_caught_error(e)
+
+    response = raw_response.json()
+    if response:
+        return response["access_token"]
+
+    return None
+
+
+def revoke_edl_token(
+    username: str,
+    password: str,
+    edl_env: str,
+    token: str,
+) -> None:
+    """Revoke a token
+
+    :param username: the username of the Earthdata Login user
+    :param password: the password of the Earthdata Login user
+    :param edl_env: the environment of the Earthdata Login user (ex. 'SIT')
+    :param token: the token to revoke
+    :returns: None
+    """
+    try:
+        url = f"{get_edl_url(edl_env)}/api/users/revoke_token"
+        response = requests.post(
+            url,
+            params={"token": token},
+            auth=(username, password),
+        )
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        raise parse_http_error(e, "revoke")
+    except Exception as e:
+        raise parse_caught_error(e)
+
+
+def get_edl_token(
+    username: str,
+    password: str,
+    edl_env: str,
+) -> Optional[str]:
+    """Get a token by retrieving an existing token or creating a new one
+
+    :param username: the username of the Earthdata Login user
+    :param password: the password of the Earthdata Login user
+    :param edl_env: the environment of the Earthdata Login (ex. 'SIT')
+    :returns: Optional[str] - the JSON Web Token string or undefined
+    """
+    token = retrieve_edl_token(username, password, edl_env)
+    if token is None:
+        token = create_edl_token(username, password, edl_env)
+
+    return token

--- a/cumulus_port/cmr_client/get_url.py
+++ b/cumulus_port/cmr_client/get_url.py
@@ -1,0 +1,76 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/cmr-client/src/getUrl.ts
+
+import os
+from typing import Optional
+
+
+def get_cmr_host(
+    *,
+    cmr_environment: Optional[str] = os.getenv("CMR_ENVIRONMENT"),
+    cmr_host: Optional[str] = os.getenv("CMR_HOST"),
+) -> str:
+    """Get host to use for CMR requests.
+
+    :param cmr_environment: CMR environment logical name to use for requests.
+    :param cmr_host: Custom host name to use for CMR requests.
+    :returns: str
+    """
+    if cmr_host:
+        return cmr_host
+
+    if cmr_environment in ("PROD", "OPS"):
+        return "https://cmr.earthdata.nasa.gov"
+    if cmr_environment == "UAT":
+        return "https://cmr.uat.earthdata.nasa.gov"
+    if cmr_environment == "SIT":
+        return "https://cmr.sit.earthdata.nasa.gov"
+
+    raise TypeError(f"Invalid CMR environment: {cmr_environment}")
+
+
+def get_bucket_access_url(
+    *,
+    host: Optional[str] = os.getenv("CMR_HOST"),
+    cmr_env: Optional[str] = os.getenv("CMR_ENVIRONMENT"),
+) -> str:
+    base_url = get_cmr_host(cmr_environment=cmr_env, cmr_host=host)
+    return f"{base_url}/access-control/s3-buckets/"
+
+
+def get_ingest_url(
+    *,
+    host: Optional[str] = os.getenv("CMR_HOST"),
+    cmr_env: Optional[str] = os.getenv("CMR_ENVIRONMENT"),
+    provider: str,
+) -> str:
+    base_url = get_cmr_host(cmr_environment=cmr_env, cmr_host=host)
+    return f"{base_url}/ingest/providers/{provider}/"
+
+
+def get_search_url(
+    *,
+    host: Optional[str] = os.getenv("CMR_HOST"),
+    cmr_env: Optional[str] = os.getenv("CMR_ENVIRONMENT"),
+) -> str:
+    base_url = get_cmr_host(cmr_environment=cmr_env, cmr_host=host)
+    return f"{base_url}/search/"
+
+
+def get_token_url(
+    *,
+    host: Optional[str] = os.getenv("CMR_HOST"),
+    cmr_env: Optional[str] = os.getenv("CMR_ENVIRONMENT"),
+) -> str:
+    base_url = get_cmr_host(cmr_environment=cmr_env, cmr_host=host)
+    return f"{base_url}/legacy-services/rest/tokens"
+
+
+def get_validate_url(
+    *,
+    host: Optional[str] = os.getenv("CMR_HOST"),
+    cmr_env: Optional[str] = os.getenv("CMR_ENVIRONMENT"),
+    provider: str,
+) -> str:
+    base_url = get_cmr_host(cmr_environment=cmr_env, cmr_host=host)
+    return f"{base_url}/ingest/providers/{provider}/validate/"

--- a/cumulus_port/cmr_client/search_concept.py
+++ b/cumulus_port/cmr_client/search_concept.py
@@ -1,0 +1,113 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/cmr-client/src/searchConcept.ts
+
+import logging
+import os
+from typing import Optional
+
+import requests
+
+from .get_url import get_search_url
+
+log = logging.getLogger(__name__)
+
+
+def search_concept(
+    *,
+    type: str,
+    search_params: dict,
+    previous_results: list = [],
+    headers: dict = {},
+    format: str = "json",
+    recursive: bool = True,
+    cmr_environment: Optional[str] = os.getenv("CMR_ENVIRONMENT"),
+    cmr_limit: Optional[int] = None,
+    cmr_page_size: Optional[int] = None,
+) -> list:
+    """
+    :param type: Concept type to search, choices: ['collections', 'granules']
+    :param cmr_environment: - optional, CMR environment to use valid arguments
+        are ['PROD', 'OPS', 'SIT', 'UAT']
+    :param search_params: CMR search parameters
+        Note initial searchParams.page_num should only be set if recursive is false
+    :param previous_results: array of results returned in previous recursive
+        calls to be included in the results returned
+    :param headers: the CMR headers
+    :param format: format of the response, supports umm_json, json, echo10
+    :param recursive: indicate whether search recursively to get all the result
+    :param cmr_limit: the CMR limit
+    :param cmr_page_size: the CMR page size
+    :returns: array of search results.
+    """
+    if cmr_limit is not None:
+        records_limit = cmr_limit
+    elif (env_cmr_limit := os.getenv("CMR_LIMIT")):
+        records_limit = int(env_cmr_limit)
+    else:
+        records_limit = 100
+
+    search_params_page_size = search_params.get("pageSize")
+
+    if search_params_page_size:
+        page_size = int(search_params_page_size)
+    elif cmr_page_size is not None:
+        page_size = cmr_page_size
+    elif (env_cmr_page_size := os.getenv("CMR_PAGE_SIZE")):
+        page_size = int(env_cmr_page_size)
+    else:
+        page_size = 50
+
+    query = dict(search_params)
+
+    query_page_num = query.get("page_num")
+    page_num = 1 if query_page_num is None else int(query_page_num) + 1
+
+    query["page_num"] = page_num
+
+    if "page_size" not in query:
+        query["page_size"] = str(page_size)
+
+    url = f"{get_search_url(cmr_env=cmr_environment)}{type}.{format.lower()}"
+    try:
+        response = requests.get(url, params=query, headers=headers)
+        response.raise_for_status()
+    except Exception:
+        log.error(
+            "Error executing CMR search concept.\nSearching %s\n"
+            "with search parameters %s\nand headers %s",
+            url,
+            query,
+            headers,
+        )
+        raise
+
+    if format == "echo10":
+        raise NotImplementedError()
+    else:
+        body = response.json()
+        if "items" in body:
+            response_items = body["items"]
+        else:
+            response_items = body.get("feed", {}).get("entry", [])
+
+    fetched_results = previous_results + (response_items or [])
+
+    num_records_collected = len(fetched_results)
+
+    cmr_hits = response.headers.get("cmr-hits")
+    if cmr_hits is None:
+        raise TypeError("cmr-hits header not found")
+
+    cmr_has_more_results = int(cmr_hits) > num_records_collected
+    records_limit_reached = num_records_collected >= records_limit
+    if recursive and cmr_has_more_results and not records_limit_reached:
+        return search_concept(
+            type=type,
+            search_params=query,
+            previous_results=fetched_results,
+            headers=headers,
+            format=format,
+            recursive=recursive,
+        )
+
+    return fetched_results[:records_limit]

--- a/cumulus_port/cmrjs/cmr_utils.py
+++ b/cumulus_port/cmrjs/cmr_utils.py
@@ -1,0 +1,71 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/cmrjs/src/cmr-utils.js
+
+import logging
+import os
+
+from cumulus_port import launchpad_auth as launchpad
+from cumulus_port.aws_client.secrets_manager import get_secret_string
+
+log = logging.getLogger(__name__)
+
+
+def get_cmr_settings(cmr_config: dict = {}) -> dict:
+    """Helper to build an CMR settings object, used to initialize CMR.
+
+    :param cmr_config: CMR configuration object
+        key "oauthProvider" - Oauth provider: launchpad or earthdata
+        key "provider" - the CMR provider
+        key "clientId" - Client id for CMR requests
+        key "passphraseSecretName" - Launchpad passphrase secret name
+        key "api" - Launchpad api
+        key "certificate" - Launchpad certificate
+        key "username" - EDL username
+        key "passwordSecretName" - CMR password secret name
+    :returns: dict - object to create CMR instance - contains the provider,
+        clientId, and either launchpad token or EDL username and password
+    """
+    oauth_provider = (
+        cmr_config.get("oauthProvider") or os.getenv("cmr_oauth_provider")
+    )
+
+    cmr_credentials = {
+        "provider": cmr_config.get("provider") or os.getenv("cmr_provider"),
+        "client_id": cmr_config.get("clientId") or os.getenv("cmr_client_id"),
+        "oauth_provider": oauth_provider,
+    }
+
+    if oauth_provider == "launchpad":
+        launchpad_passphrase_secret_name = (
+            cmr_config.get("passphraseSecretName")
+            or os.getenv("launchpad_passphrase_secret_name")
+        )
+        passphrase = get_secret_string(launchpad_passphrase_secret_name)
+
+        config = {
+            "passphrase": passphrase,
+            "api": cmr_config.get("api") or os.getenv("launchpad_api"),
+            "certificate": (
+                cmr_config.get("certificate")
+                or os.getenv("launchpad_certificate")
+            ),
+        }
+
+        log.debug("cmrjs.getCreds getLaunchpadToken")
+        token = launchpad.get_launchpad_token(**config)
+        return {
+            **cmr_credentials,
+            "token": token,
+        }
+
+    password_secret_name = (
+        cmr_config.get("passwordSecretName")
+        or os.getenv("cmr_password_secret_name")
+    )
+    password = get_secret_string(password_secret_name)
+
+    return {
+        **cmr_credentials,
+        "password": password,
+        "username": cmr_config.get("username") or os.getenv("cmr_username"),
+    }

--- a/cumulus_port/common/__init__.py
+++ b/cumulus_port/common/__init__.py
@@ -1,0 +1,5 @@
+from .errors import parse_caught_error
+
+__all__ = [
+    "parse_caught_error",
+]

--- a/cumulus_port/common/env.py
+++ b/cumulus_port/common/env.py
@@ -1,0 +1,20 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/common/src/env.ts
+
+import os
+
+from cumulus_port.errors import MissingRequiredEnvVarError
+
+
+def get_required_env_var(
+    name: str,
+    env: dict = os.environ,
+) -> str:
+    value = env.get(name)
+
+    if value is not None:
+        return value
+
+    raise MissingRequiredEnvVarError(
+        f"The {name} environment variable must be set",
+    )

--- a/cumulus_port/common/errors.py
+++ b/cumulus_port/common/errors.py
@@ -1,0 +1,17 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/common/src/errors.ts
+
+from typing import Any
+
+
+def parse_caught_error(e: Any) -> Exception:
+    """This method is for parsing a caught error which is not an HTTPerror in
+    case the EDL endpoint call results in an unexpected error
+
+    :param e: the Error, if e isn't of type Error then it returns itself
+    :returns: Exception
+    """
+    if isinstance(e, Exception):
+        return e
+
+    return Exception(f"{e}")

--- a/cumulus_port/errors/__init__.py
+++ b/cumulus_port/errors/__init__.py
@@ -1,0 +1,5 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/errors/src/index.ts
+
+class MissingRequiredEnvVarError(Exception):
+    pass

--- a/cumulus_port/ingest/url_path_template.py
+++ b/cumulus_port/ingest/url_path_template.py
@@ -21,7 +21,7 @@ def _get_single_value(data: dict, path: str):
     return values[0]
 
 
-def evaluate_operation(name, args):
+def evaluate_operation(name: str, args: list) -> str:
     """evaluate the operation specified in template
 
     :param name: the name of the operation

--- a/cumulus_port/launchpad_auth/__init__.py
+++ b/cumulus_port/launchpad_auth/__init__.py
@@ -1,0 +1,93 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/launchpad-auth/src/index.ts
+
+import json
+import logging
+import time
+from typing import Optional
+
+import boto3
+
+from cumulus_port.aws_client.s3 import s3_join, s3_object_exists
+
+from .launchpad_token import LaunchpadToken
+from .utils import get_env_var
+
+log = logging.getLogger(__name__)
+
+
+def launchpad_token_bucket_key() -> dict[str, str]:
+    """Get S3 location of the Launchpad token
+
+    :returns: dict - S3 Bucket and Key where Launchpad token is stored
+    """
+    bucket = get_env_var("system_bucket")
+    stack_name = get_env_var("stackName")
+    return {
+        "Bucket": bucket,
+        "Key": s3_join(stack_name, "launchpad/token.json"),
+    }
+
+
+def get_valid_launchpad_token_from_s3() -> Optional[str]:
+    """Retrieve Launchpad token from S3
+
+    :returns: Optional[str] - the Launchpad token, None if token doesn't exist
+        or invalid
+    """
+    s3 = boto3.client("s3")
+    s3location = launchpad_token_bucket_key()
+    key_exists = s3_object_exists(s3, **s3location)
+
+    token = None
+    if key_exists:
+        s3object = s3.get_object(**s3location)
+        launchpad_token = json.load(s3object["Body"])
+        now = time.time()
+        token_expiration_in_sec = (
+            launchpad_token["session_maxtimeout"]
+            + launchpad_token["session_starttime"]
+        )
+
+        # check if token is still valid
+        if now < token_expiration_in_sec:
+            token = launchpad_token["sm_token"]
+
+    return token
+
+
+def get_launchpad_token(*, api: str, passphrase: str, certificate: str) -> str:
+    """Get a Launchpad token
+
+    :param api: the Launchpad token service api endpoint
+    :param passphrase: the passphrase of the Launchpad PKI certificate
+    :param certificate: the name of the Launchpad PKI pfx certificate
+    :returns: str - the Launchpad token
+    """
+    token = get_valid_launchpad_token_from_s3()
+
+    if not token:
+        log.debug("getLaunchpadToken requesting launchpad token")
+        launchpad = LaunchpadToken(
+            api=api,
+            passphrase=passphrase,
+            certificate=certificate,
+        )
+        token_response = launchpad.request_token()
+        # add session_starttime to token object, assume token is generated 5 min ago
+        token_object = {
+            **token_response,
+            "session_starttime": int(time.time()) - (5 * 60),
+        }
+
+        s3location = launchpad_token_bucket_key()
+        s3 = boto3.client("s3")
+        s3.put_object(
+            Bucket=s3location["Bucket"],
+            Key=s3location["Key"],
+            Body=json.dumps(token_object),
+        )
+
+        token = token_object["sm_token"]
+
+    return token

--- a/cumulus_port/launchpad_auth/launchpad_token.py
+++ b/cumulus_port/launchpad_auth/launchpad_token.py
@@ -1,0 +1,109 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/launchpad-auth/src/LaunchpadToken.ts
+
+import logging
+import urllib.parse
+
+import boto3
+import requests
+
+from cumulus_port._internal.pfx_to_pem import pfx_to_pem
+from cumulus_port.aws_client.s3 import s3_object_exists
+
+from .utils import get_env_var
+
+log = logging.getLogger(__name__)
+
+
+class LaunchpadToken:
+    """A class for sending requests to Launchpad token service endpoints
+
+    Example:
+    >>> launchpad_token = LaunchpadToken(
+    ...     api="launchpad-token-api-endpoint",
+    ...     passphrase="my-pki-passphrase",
+    ...     certificate="my-pki-certificate.pfx",
+    ... )
+    ...
+    """
+
+    def __init__(self, *, api: str, passphrase: str, certificate: str):
+        """
+        :param api: the Launchpad token service api endpoint
+        :param passphrase: the passphrase of the Launchpad PKI certificate
+        :param certificate: the name of the Launchpad PKI pfx certificate
+        """
+        self.api = api
+        self.passphrase = passphrase
+        self.certificate = certificate
+
+    def retrieve_certificate(self) -> bytes:
+        """Retrieve Launchpad credentials
+
+        :returns: Optional[bytes] - body of certificate found on S3
+        """
+        bucket = get_env_var("system_bucket")
+        stack_name = get_env_var("stackName")
+
+        # we are assuming that the specified certificate file is in the S3
+        # crypto directory
+        crypt_key = f"{stack_name}/crypto/{self.certificate}"
+
+        s3 = boto3.client("s3")
+        key_exists = s3_object_exists(
+            s3,
+            Bucket=bucket,
+            Key=crypt_key,
+        )
+
+        if not key_exists:
+            raise Exception(
+                f"{self.certificate} does not exist in S3 {bucket} crypto "
+                f"directory: {crypt_key}",
+            )
+
+        log.debug(
+            "Reading Key: %s bucket:%s,stack:%s",
+            self.certificate,
+            bucket,
+            stack_name,
+        )
+
+        pfx_object = s3.get_object(
+            Bucket=bucket,
+            Key=crypt_key,
+        )
+        return pfx_object["Body"].read()
+
+    def request_token(self) -> dict:
+        """Get a token from Launchpad
+
+        :returns: dict - the Launchpad gettoken response object
+        """
+        log.debug("LaunchpadToken.requestToken")
+        pfx = self.retrieve_certificate()
+
+        with pfx_to_pem(pfx, self.passphrase) as cert:
+            url = urllib.parse.urljoin(f"{self.api}/", "gettoken")
+            response = requests.get(url, cert=cert)
+            response.raise_for_status()
+            return response.json()
+
+    def validate_token(self, token: str) -> dict:
+        """Validate a Launchpad token
+
+        :param token: the Launchpad token for validation
+        :returns: dict - the Launchpad validate token response object
+        """
+        log.debug("LaunchpadToken.validateToken")
+        pfx = self.retrieve_certificate()
+
+        with pfx_to_pem(pfx, self.passphrase) as cert:
+            url = urllib.parse.urljoin(f"{self.api}/", "validate")
+            response = requests.post(
+                url,
+                json={"token": token},
+                cert=cert,
+            )
+            response.raise_for_status()
+            return response.json()

--- a/cumulus_port/launchpad_auth/utils.py
+++ b/cumulus_port/launchpad_auth/utils.py
@@ -1,0 +1,12 @@
+# Ported from:
+# https://github.com/nasa/cumulus/blob/master/packages/launchpad-auth/src/utils.ts
+
+import os
+
+
+def get_env_var(name: str) -> str:
+    env_var = os.getenv(name)
+    if not env_var:
+        raise Exception(f"Must set environment variable {name}")
+
+    return env_var

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,24 @@ build-backend = "poetry.core.masonry.api"
 python = ">=3.9"
 
 # Required
+boto3 = "^1.0.0"
+botocore = "*"
+cryptography = ">=35.0.0"
 jsonpath-ng = "^1.4.0"
+pyjwt = "^2.0.0"
+requests = "^2.4.2"
 
 [tool.poetry.group.dev.dependencies]
+moto = "^5.0.18"
 pytest = "^8.0.2"
 pytest-cov = "^4.0.0"
+pytest-mock = "^3.14.0"
 
 [tool.pytest.ini_options]
 pythonpath="."
+markers = [
+    "auth: requires the 'auth' extra to be installed",
+]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cumulus-port"
-version = "0.1.0"
+version = "0.1.1"
 description = "A python port of core cumulus functions"
 authors = ["Rohan Weeden <reweeden@alaska.edu>"]
 license = "APACHE-2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,8 @@ jsonpath-ng = "^1.4.0"
 pytest = "^8.0.2"
 pytest-cov = "^4.0.0"
 
+[tool.pytest.ini_options]
+pythonpath="."
+
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,18 @@ build-backend = "poetry.core.masonry.api"
 python = ">=3.9"
 
 # Required
-boto3 = "^1.0.0"
-botocore = "*"
-cryptography = ">=35.0.0"
 jsonpath-ng = "^1.4.0"
-pyjwt = "^2.0.0"
-requests = "^2.4.2"
+
+# Optional
+boto3 = { version = "^1.0.0", optional = true }
+botocore = { version = "*", optional = true }
+cryptography = { version = ">=35.0.0", optional = true }
+pyjwt = { version = "^2.0.0", optional = true }
+requests = { version = "^2.4.2", optional = true }
+
+[tool.poetry.extras]
+all = ["boto3", "botocore", "cryptography", "pyjwt", "requests"]
+auth = ["boto3", "botocore", "cryptography", "pyjwt", "requests"]
 
 [tool.poetry.group.dev.dependencies]
 moto = "^5.0.18"

--- a/tests/cumulus/conftest.py
+++ b/tests/cumulus/conftest.py
@@ -1,4 +1,37 @@
+import os
+
+import boto3
 import pytest
+from moto import mock_aws
+
+
+@pytest.fixture(scope="session", autouse=True)
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+
+@pytest.fixture
+def s3_client():
+    with mock_aws():
+        yield boto3.client("s3")
+
+
+@pytest.fixture
+def s3_resource():
+    with mock_aws():
+        yield boto3.resource("s3")
+
+
+@pytest.fixture
+def s3_bucket(s3_resource):
+    bucket = s3_resource.Bucket("test-bucket")
+    bucket.create()
+    return bucket
 
 
 @pytest.fixture

--- a/tests/cumulus/test_cmr.py
+++ b/tests/cumulus/test_cmr.py
@@ -1,0 +1,189 @@
+import pytest
+from moto import mock_aws
+
+try:
+    import boto3
+
+    from cumulus_port.cmr_client import CMR
+    from cumulus_port.cmr_client.cmr import update_token
+    from cumulus_port.errors import MissingRequiredEnvVarError
+except ImportError:
+    pass
+
+pytestmark = pytest.mark.auth
+
+
+@pytest.fixture
+def cmr_password_secret_name():
+    secret_name = "test_cmr_passwrd"
+    with mock_aws():
+        client = boto3.client("secretsmanager")
+        client.create_secret(
+            Name=secret_name,
+            SecretString="password",
+        )
+        yield secret_name
+
+
+def test_update_token(monkeypatch, mocker):
+    with pytest.raises(MissingRequiredEnvVarError):
+        update_token("username", "password")
+
+    monkeypatch.setenv("CMR_ENVIRONMENT", "")
+    with pytest.raises(Exception, match="CMR_ENVIRONMENT not set"):
+        update_token("username", "password")
+
+    monkeypatch.setenv("CMR_ENVIRONMENT", "UAT")
+    mocker.patch(
+        "cumulus_port.cmr_client.cmr.get_edl_token",
+        return_value="edl-token",
+    )
+
+    assert update_token("username", "password") == "edl-token"
+
+
+def test_get_cmr_password(cmr_password_secret_name):
+    kwargs = {
+        "provider": "TEST",
+        "client_id": "unit-tests",
+        "oauth_provider": "earthdata",
+    }
+    assert CMR(password="foobar", **kwargs).get_cmr_password() == "foobar"
+    assert CMR(
+        password_secret_name=cmr_password_secret_name,
+        **kwargs,
+    ).get_cmr_password() == "password"
+
+    with pytest.raises(Exception, match="No CMR password set"):
+        CMR(**kwargs).get_cmr_password()
+
+    with pytest.raises(Exception, match="Unable to retrieve CMR password"):
+        CMR(
+            password_secret_name="does-not-exist",
+            **kwargs,
+        ).get_cmr_password()
+
+
+def test_get_token(mocker):
+    kwargs = {
+        "provider": "TEST",
+        "client_id": "unit-tests",
+        "oauth_provider": "earthdata",
+    }
+    assert CMR(token="the-token", **kwargs).get_token() == "the-token"
+
+    mock_update_token = mocker.patch(
+        "cumulus_port.cmr_client.cmr.update_token",
+        return_value="the-new-token",
+    )
+    assert CMR(
+        username="username",
+        password="password",
+        **kwargs,
+    ).get_token() == "the-new-token"
+    mock_update_token.assert_called_once_with("username", "password")
+
+
+def test_get_read_headers():
+    cmr_client = CMR(
+        provider="TEST",
+        client_id="unit-test-client-id",
+        oauth_provider="earthdata",
+    )
+    assert cmr_client.get_read_headers() == {
+        "Client-Id": "unit-test-client-id",
+    }
+    assert cmr_client.get_read_headers(token="the-token") == {
+        "Client-Id": "unit-test-client-id",
+        "Authorization": "the-token",
+    }
+
+
+def test_search_concept(mocker):
+    cmr_client = CMR(
+        provider="TEST",
+        client_id="unit-test-client-id",
+        oauth_provider="earthdata",
+        token="the-token",
+    )
+    mock_search_concept = mocker.patch(
+        "cumulus_port.cmr_client.cmr.search_concept",
+        return_value=[{"foo": "bar"}],
+    )
+
+    assert cmr_client.search_concept("some-type", {"a": "b"}) == [
+        {"foo": "bar"},
+    ]
+    mock_search_concept.assert_called_once_with(
+        type="some-type",
+        search_params={"a": "b"},
+        previous_results=[],
+        headers={
+            "Client-Id": "unit-test-client-id",
+            "Authorization": "the-token",
+        },
+        format="json",
+        recursive=True,
+    )
+
+
+def test_search_collections(mocker):
+    cmr_client = CMR(
+        provider="TEST",
+        client_id="unit-test-client-id",
+        oauth_provider="earthdata",
+        token="the-token",
+    )
+    mock_search_concept = mocker.patch(
+        "cumulus_port.cmr_client.cmr.search_concept",
+        return_value=[{"foo": "bar"}],
+    )
+
+    assert cmr_client.search_collections({"a": "b"}, "umm_json") == [
+        {"foo": "bar"},
+    ]
+    mock_search_concept.assert_called_once_with(
+        type="collections",
+        search_params={
+            "provider_short_name": "TEST",
+            "a": "b",
+        },
+        previous_results=[],
+        headers={
+            "Client-Id": "unit-test-client-id",
+            "Authorization": "the-token",
+        },
+        format="umm_json",
+        recursive=True,
+    )
+
+
+def test_search_granules(mocker):
+    cmr_client = CMR(
+        provider="TEST",
+        client_id="unit-test-client-id",
+        oauth_provider="earthdata",
+        token="the-token",
+    )
+    mock_search_concept = mocker.patch(
+        "cumulus_port.cmr_client.cmr.search_concept",
+        return_value=[{"foo": "bar"}],
+    )
+
+    assert cmr_client.search_granules({"a": "b"}, "umm_json") == [
+        {"foo": "bar"},
+    ]
+    mock_search_concept.assert_called_once_with(
+        type="granules",
+        search_params={
+            "provider_short_name": "TEST",
+            "a": "b",
+        },
+        previous_results=[],
+        headers={
+            "Client-Id": "unit-test-client-id",
+            "Authorization": "the-token",
+        },
+        format="umm_json",
+        recursive=True,
+    )

--- a/tests/cumulus/test_cmr_utils.py
+++ b/tests/cumulus/test_cmr_utils.py
@@ -1,0 +1,55 @@
+from cumulus_port.cmrjs.cmr_utils import get_cmr_settings
+
+
+def test_get_cmr_settings_launchpad(mocker):
+    cmr = {
+        "clientId": "unit-test-client-id",
+        "cmrEnvironment": "UAT",
+        "cmrLimit": 100,
+        "cmrPageSize": 50,
+        "oauthProvider": "launchpad",
+        "passwordSecretName": "cmr-password-secret-name",
+        "provider": "ASFDEV",
+        "username": "username",
+    }
+    launchpad = {
+        "api": "https://api.launchpad.nasa.gov/icam/api/sm/v1",
+        "certificate": "Modify-012345678.pfx",
+        "passphraseSecretName": "launchpad-passphrase-secret-name",
+    }
+    mocker.patch(
+        "cumulus_port.cmrjs.cmr_utils.launchpad.get_launchpad_token",
+        return_value="the-launchpad-token",
+    )
+
+    assert get_cmr_settings({**cmr, **launchpad}) == {
+        "client_id": "unit-test-client-id",
+        "oauth_provider": "launchpad",
+        "provider": "ASFDEV",
+        "token": "the-launchpad-token",
+    }
+
+
+def test_get_cmr_settings_earthdata(mocker):
+    cmr = {
+        "clientId": "unit-test-client-id",
+        "cmrEnvironment": "UAT",
+        "cmrLimit": 100,
+        "cmrPageSize": 50,
+        "oauthProvider": "earthdata",
+        "passwordSecretName": "cmr-password-secret-name",
+        "provider": "ASFDEV",
+        "username": "username",
+    }
+    mocker.patch(
+        "cumulus_port.cmrjs.cmr_utils.get_secret_string",
+        return_value="password",
+    )
+
+    assert get_cmr_settings(cmr) == {
+        "provider": "ASFDEV",
+        "client_id": "unit-test-client-id",
+        "oauth_provider": "earthdata",
+        "password": "password",
+        "username": "username",
+    }

--- a/tests/cumulus/test_earthdata_login.py
+++ b/tests/cumulus/test_earthdata_login.py
@@ -1,0 +1,30 @@
+import pytest
+
+try:
+    from cumulus_port.cmr_client.earthdata_login import get_edl_token, get_edl_url
+except ImportError:
+    pass
+
+
+pytestmark = pytest.mark.auth
+
+
+def test_get_edl_url():
+    assert get_edl_url("PROD") == "https://urs.earthdata.nasa.gov"
+    assert get_edl_url("UAT") == "https://uat.urs.earthdata.nasa.gov"
+    assert get_edl_url("SIT") == "https://sit.urs.earthdata.nasa.gov"
+
+
+def test_get_edl_token(mocker):
+    mock_retrieve_edl_token = mocker.patch(
+        "cumulus_port.cmr_client.earthdata_login.retrieve_edl_token",
+        return_value=None,
+    )
+    mocker.patch(
+        "cumulus_port.cmr_client.earthdata_login.create_edl_token",
+        return_value="the-new-token",
+    )
+    assert get_edl_token("username", "password", "UAT") == "the-new-token"
+
+    mock_retrieve_edl_token.return_value = "old-token"
+    assert get_edl_token("username", "password", "UAT") == "old-token"

--- a/tests/cumulus/test_get_url.py
+++ b/tests/cumulus/test_get_url.py
@@ -1,0 +1,76 @@
+import pytest
+
+try:
+    from cumulus_port.cmr_client.get_url import (
+        get_bucket_access_url,
+        get_cmr_host,
+        get_ingest_url,
+        get_search_url,
+        get_token_url,
+        get_validate_url,
+    )
+except ImportError:
+    pass
+
+
+pytestmark = pytest.mark.auth
+
+
+def test_get_cmr_host():
+    assert get_cmr_host(
+        cmr_environment="PROD",
+        cmr_host=None,
+    ) == "https://cmr.earthdata.nasa.gov"
+    assert get_cmr_host(
+        cmr_environment="UAT",
+        cmr_host=None,
+    ) == "https://cmr.uat.earthdata.nasa.gov"
+    assert get_cmr_host(
+        cmr_environment="SIT",
+        cmr_host=None,
+    ) == "https://cmr.sit.earthdata.nasa.gov"
+
+    assert get_cmr_host(
+        cmr_environment="FOO",
+        cmr_host="https://foo.bar",
+    ) == "https://foo.bar"
+
+    with pytest.raises(TypeError, match="Invalid CMR environment: FOO"):
+        assert get_cmr_host(cmr_environment="FOO", cmr_host=None)
+
+
+def test_get_bucket_access_url():
+    assert get_bucket_access_url(
+        host=None,
+        cmr_env="PROD",
+    ) == "https://cmr.earthdata.nasa.gov/access-control/s3-buckets/"
+
+
+def test_get_ingest_url():
+    assert get_ingest_url(
+        host=None,
+        cmr_env="PROD",
+        provider="ASFDEV",
+    ) == "https://cmr.earthdata.nasa.gov/ingest/providers/ASFDEV/"
+
+
+def test_get_search_url():
+    assert get_search_url(
+        host=None,
+        cmr_env="PROD",
+    ) == "https://cmr.earthdata.nasa.gov/search/"
+
+
+def test_get_token_url():
+    assert get_token_url(
+        host=None,
+        cmr_env="PROD",
+    ) == "https://cmr.earthdata.nasa.gov/legacy-services/rest/tokens"
+
+
+def test_get_validate_url():
+    assert get_validate_url(
+        host=None,
+        cmr_env="PROD",
+        provider="ASFDEV",
+    ) == "https://cmr.earthdata.nasa.gov/ingest/providers/ASFDEV/validate/"

--- a/tests/cumulus/test_launchpad_auth.py
+++ b/tests/cumulus/test_launchpad_auth.py
@@ -1,0 +1,51 @@
+import json
+import time
+
+from moto import mock_aws
+
+from cumulus_port.launchpad_auth import (
+    get_launchpad_token,
+    get_valid_launchpad_token_from_s3,
+    launchpad_token_bucket_key,
+)
+
+
+def test_launchpad_token_bucket_key(s3_bucket, monkeypatch):
+    monkeypatch.setenv("system_bucket", s3_bucket.name)
+    monkeypatch.setenv("stackName", "test-stack")
+    assert launchpad_token_bucket_key() == {
+        "Bucket": "test-bucket",
+        "Key": "test-stack/launchpad/token.json",
+    }
+
+
+def test_get_valid_launchpad_token_from_s3(s3_bucket, monkeypatch):
+    obj = s3_bucket.Object("test-stack/launchpad/token.json")
+    obj.put(
+        Body=json.dumps({
+            "session_maxtimeout": 5000,
+            "session_starttime": int(time.time()),
+            "sm_token": "the-token",
+        }),
+    )
+
+    monkeypatch.setenv("system_bucket", s3_bucket.name)
+    monkeypatch.setenv("stackName", "test-stack")
+    assert get_valid_launchpad_token_from_s3() == "the-token"
+
+
+@mock_aws
+def test_get_launchpad_token(s3_bucket, mocker, monkeypatch):
+    mocker.patch(
+        "cumulus_port.launchpad_auth.LaunchpadToken.request_token",
+        return_value={
+            "sm_token": "the-token",
+        },
+    )
+    monkeypatch.setenv("system_bucket", s3_bucket.name)
+    monkeypatch.setenv("stackName", "test-stack")
+    assert get_launchpad_token(
+        api="foo",
+        passphrase="foo",
+        certificate="foo",
+    ) == "the-token"

--- a/tests/cumulus/test_launchpad_token.py
+++ b/tests/cumulus/test_launchpad_token.py
@@ -1,0 +1,21 @@
+import pytest
+
+from cumulus_port.launchpad_auth.launchpad_token import LaunchpadToken
+
+
+def test_retrieve_certificate(s3_bucket, monkeypatch):
+    monkeypatch.setenv("system_bucket", s3_bucket.name)
+    monkeypatch.setenv("stackName", "test-stack")
+
+    launchpad = LaunchpadToken(
+        api="foo",
+        passphrase="foo",
+        certificate="Modify.pfx",
+    )
+    with pytest.raises(Exception, match="Modify.pfx does not exist in S3"):
+        launchpad.retrieve_certificate()
+
+    obj = s3_bucket.Object("test-stack/crypto/Modify.pfx")
+    obj.put(Body="CERTIFICATE")
+
+    assert launchpad.retrieve_certificate() == b"CERTIFICATE"

--- a/tests/cumulus/test_s3.py
+++ b/tests/cumulus/test_s3.py
@@ -1,0 +1,22 @@
+from cumulus_port.aws_client.s3 import s3_join, s3_object_exists
+
+
+def test_s3_join():
+    assert s3_join() == ""
+
+    assert s3_join("foo", "bar") == "foo/bar"
+    assert s3_join("foo", "bar/") == "foo/bar/"
+    assert s3_join("/foo", "/bar") == "foo/bar"
+    assert s3_join("/foo/", "/bar") == "foo/bar"
+    assert s3_join("//foo/", "/bar") == "/foo/bar"
+    assert s3_join("foo", "bar", "baz", "qux") == "foo/bar/baz/qux"
+
+    assert s3_join(["foo", "bar"]) == "foo/bar"
+
+
+def test_s3_object_exists(s3_client, s3_bucket):
+    obj = s3_bucket.Object("test-key")
+    obj.put(Body="test")
+
+    assert s3_object_exists(s3_client, Bucket=obj.bucket_name, Key=obj.key)
+    assert not s3_object_exists(s3_client, Bucket=obj.bucket_name, Key="fake")

--- a/tests/cumulus/test_secrets_manager.py
+++ b/tests/cumulus/test_secrets_manager.py
@@ -1,0 +1,16 @@
+import boto3
+from moto import mock_aws
+
+from cumulus_port.aws_client.secrets_manager import get_secret_string
+
+
+@mock_aws
+def test_get_secret_string():
+    client = boto3.client("secretsmanager")
+    client.create_secret(
+        Name="test-secret",
+        SecretString="The secret value",
+    )
+
+    assert get_secret_string("test-secret") == "The secret value"
+    assert get_secret_string("does-not-exist") is None

--- a/tox.ini
+++ b/tox.ini
@@ -14,10 +14,13 @@ python =
 [testenv]
 allowlist_externals = poetry
 deps =
+    moto~=5.0
+    pytest-cov~=4.0
+    pytest-mock~=3.14
     pytest~=8.1
 extras =
     Xnone:
     Xall: all
 commands =
-    Xnone: pytest tests/ {posargs}
+    Xnone: pytest tests/ -m "not auth" {posargs}
     Xall: pytest tests/ {posargs}


### PR DESCRIPTION
Brings in the necessary CMR and Launchpad code to be able to query granules in a non-public collection as needed for the Zarr stack generation in SBX and SIT accounts. This also means in UAT and PROD the queries will come from authenticated connections which probably provides traceability on the CMR side.

Each file that came directly from cumulus should have a `# Ported from` comment at the top linking to the original file. I also had to create a helper for making the .pfx certificate work with python requests that I put into the `_internal` submodule.

Docstrings are directly copied from the doc comments in cumulus and adjusted to fit with our coding standards.

Parameters are renamed to snake case.

Any functions that take params via a single JS object in cumulus are converted to keyword-only functions with the `*` parameter to allow us to preserve the definition order, even when arguments with defaults precede required arguments.

I tried to include type annotations wherever possible without getting into `TypedDict` territory. So a number of things end up with just `dict` as the type (effectively `dict[Any, Any]`).